### PR TITLE
内存泄露

### DIFF
--- a/AliyunOSSiOS/OSSNetworking.m
+++ b/AliyunOSSiOS/OSSNetworking.m
@@ -417,6 +417,17 @@
         }
         [sessionTask resume];
 
+        /** 
+         内存泄露点，两个强引用指向 OSSNetworking 这个对象
+         
+         1.sessionWithConfiguration:delegate:delegateQueue: 这个回调delegate会被强引用
+         2.当不再需要连接调用Session的时候，调用invalidateAndCancel直接关闭，或者调用finishTasksAndInvalidate等待当前Task结束后关闭。
+         3.这时Delegate会收到URLSession:didBecomeInvalidWithError:这个事件。
+         4.Delegate收到这个事件之后会被解引用。
+         */
+        [_dataSession finishTasksAndInvalidate];
+        [_uploadFileSession finishTasksAndInvalidate];
+      
         return task;
     }] continueWithBlock:^id(OSSTask *task) {
 


### PR DESCRIPTION
1. 两个强引用指向 OSSNetworking 这个对象，导致Networking不被释放
2. `sessionWithConfiguration:delegate:delegateQueue:` 这个回调`delegate`会被强引用
3. 当不再需要连接调用`Session`的时候，需要对`delegate`解引用
