### PR TITLE
去除时间校对的逻辑

### DIFF
--- a/AliyunOSSiOS/OSSNetworking.m
+++ b/AliyunOSSiOS/OSSNetworking.m
@@ -446,15 +446,15 @@
         return ;
     }
 
-    NSString * dateStr = [[httpResponse allHeaderFields] objectForKey:@"Date"];
-    if ([dateStr length]) {
-        NSDate * serverTime = [NSDate oss_dateFromString:dateStr];
-        NSDate * deviceTime = [NSDate date];
-        NSTimeInterval skewTime = [deviceTime timeIntervalSinceDate:serverTime];
-        [NSDate oss_setClockSkew:skewTime];
-    } else {
-        OSSLogError(@"date header does not exist, unable to adjust the time skew");
-    }
+//    NSString * dateStr = [[httpResponse allHeaderFields] objectForKey:@"Date"];
+//    if ([dateStr length]) {
+//        NSDate * serverTime = [NSDate oss_dateFromString:dateStr];
+//        NSDate * deviceTime = [NSDate date];
+//        NSTimeInterval skewTime = [deviceTime timeIntervalSinceDate:serverTime];
+//        [NSDate oss_setClockSkew:skewTime];
+//    } else {
+//        OSSLogError(@"date header does not exist, unable to adjust the time skew");
+//    }
 
     /* background upload task will not call back didRecieveResponse */
     if (delegate.isBackgroundUploadFileTask) {


### PR DESCRIPTION
在我们使用CDN的时侯，资源被缓存到CDN之后，时间戳不在更新，而SDK会根据这个时间戳来修正本地的时间，当时间被更新之后，之后的所有请求会失败。