### PR TITLE
时间同步逻辑优化

### DIFF
--- a/AliyunOSSSDK/OSSClient.m
+++ b/AliyunOSSSDK/OSSClient.m
@@ -1406,7 +1406,7 @@ static NSObject *lock;
     OSSTask * uploadPartTask = [self uploadPart:uploadPart];
     [uploadPartTask waitUntilFinished];
     if (uploadPartTask.error) {
-        if (uploadPartTask.error.code != -409) {
+        if (abs(uploadPartTask.error.code) != 409) {
             *errorTask = uploadPartTask;
         }
     } else {
@@ -1753,7 +1753,7 @@ static NSObject *lock;
             [uploadPartTask waitUntilFinished];
             
             if (uploadPartTask.error) {
-                if (uploadPartTask.error.code != -409) {
+                if (abs(uploadPartTask.error.code) != 409) {
                     errorTask = uploadPartTask;
                     break;
                 } else {

--- a/AliyunOSSSDK/OSSClient.m
+++ b/AliyunOSSSDK/OSSClient.m
@@ -1606,6 +1606,8 @@ static NSObject *lock;
         }
         
         request.uploadId = uploadId;
+        localPartInfosPath = [[[NSString oss_documentDirectory] stringByAppendingPathComponent:oss_partInfos_storage_name] stringByAppendingPathComponent:uploadId];
+        
         if (request.isCancelled)
         {
             if(resumable)

--- a/AliyunOSSSDK/OSSClient.m
+++ b/AliyunOSSSDK/OSSClient.m
@@ -1546,11 +1546,6 @@ static NSObject *lock;
                 NSScanner *scanner = [NSScanner scannerWithString: partNumberString];
                 [scanner scanUnsignedLongLong: &remotePartNumber];
                 
-                unsigned long long remotePartHashCode = 0;
-                NSString *hashCode = [partInfo objectForKey:OSSPartHashCodeXMLTOKEN];
-                scanner = [NSScanner scannerWithString:hashCode];
-                [scanner scanUnsignedLongLong:&remotePartHashCode];
-                
                 NSString *remotePartEtag = [partInfo objectForKey:OSSETagXMLTOKEN];
                 
                 unsigned long long remotePartSize = 0;
@@ -1564,18 +1559,12 @@ static NSObject *lock;
                 OSSPartInfo * info = [[OSSPartInfo alloc] init];
                 info.partNum = remotePartNumber;
                 info.size = remotePartSize;
-                info.crc64 = remotePartHashCode;
                 info.eTag = remotePartEtag;
                 
 #pragma clang diagnostic pop
-                
-                if (!hashCode) {
-                    NSDictionary *tPartInfo = [localPartInfos objectForKey:[NSString stringWithFormat:@"%llu",remotePartNumber]];
-                    if (tPartInfo[@"crc64"])
-                    {
-                        info.crc64 = [tPartInfo[@"crc64"] unsignedLongLongValue];
-                    }
-                }
+            
+                NSDictionary *tPartInfo = [localPartInfos objectForKey: [@(remotePartNumber) stringValue]];
+                info.crc64 = [tPartInfo[@"crc64"] unsignedLongLongValue];
                 
                 [uploadedPartInfos addObject:info];
                 [alreadyUploadIndex addObject:@(remotePartNumber)];

--- a/AliyunOSSSDK/OSSDefine.h
+++ b/AliyunOSSSDK/OSSDefine.h
@@ -54,7 +54,6 @@
 #define OSSMaxPartsXMLTOKEN                     @"MaxParts"
 #define OSSPartXMLTOKEN                         @"Part"
 #define OSSPartNumberXMLTOKEN                   @"PartNumber"
-#define OSSPartHashCodeXMLTOKEN                 @"HashCrc64ecma"
 
 #define OSSClientErrorDomain                    @"com.aliyun.oss.clientError"
 #define OSSServerErrorDomain                    @"com.aliyun.oss.serverError"

--- a/AliyunOSSSDK/OSSDefine.h
+++ b/AliyunOSSSDK/OSSDefine.h
@@ -54,6 +54,7 @@
 #define OSSMaxPartsXMLTOKEN                     @"MaxParts"
 #define OSSPartXMLTOKEN                         @"Part"
 #define OSSPartNumberXMLTOKEN                   @"PartNumber"
+#define OSSPartHashCodeXMLTOKEN                 @"HashCrc64ecma"
 
 #define OSSClientErrorDomain                    @"com.aliyun.oss.clientError"
 #define OSSServerErrorDomain                    @"com.aliyun.oss.serverError"

--- a/AliyunOSSSDK/OSSDefine.h
+++ b/AliyunOSSSDK/OSSDefine.h
@@ -16,7 +16,7 @@
 #elif TARGET_OS_OSX
 #define OSSUAPrefix                             @"aliyun-sdk-mac"
 #endif
-#define OSSSDKVersion                           @"2.10.6"
+#define OSSSDKVersion                           @"2.10.7"
 
 #define OSSListBucketResultXMLTOKEN             @"ListBucketResult"
 #define OSSNameXMLTOKEN                         @"Name"

--- a/AliyunOSSSDK/OSSNetworking.m
+++ b/AliyunOSSSDK/OSSNetworking.m
@@ -410,9 +410,6 @@
      */
     
     NSString * host = [[task.currentRequest allHTTPHeaderFields] objectForKey:@"Host"];
-    if (!host) {
-        host = task.currentRequest.URL.host;
-    }
     
     if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
         if ([self evaluateServerTrust:challenge.protectionSpace.serverTrust forDomain:host]) {
@@ -423,7 +420,7 @@
         disposition = NSURLSessionAuthChallengePerformDefaultHandling;
     }
     // Uses the default evaluation for other challenges.
-    completionHandler(disposition,credential);
+    completionHandler(disposition, credential);
 }
 
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session

--- a/AliyunOSSSDK/OSSNetworking.m
+++ b/AliyunOSSSDK/OSSNetworking.m
@@ -410,6 +410,9 @@
      */
     
     NSString * host = [[task.currentRequest allHTTPHeaderFields] objectForKey:@"Host"];
+    if (!host) {
+        host = task.currentRequest.URL.host;
+    }
     
     if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
         if ([self evaluateServerTrust:challenge.protectionSpace.serverTrust forDomain:host]) {
@@ -420,7 +423,7 @@
         disposition = NSURLSessionAuthChallengePerformDefaultHandling;
     }
     // Uses the default evaluation for other challenges.
-    completionHandler(disposition, credential);
+    completionHandler(disposition,credential);
 }
 
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session

--- a/AliyunOSSSDK/OSSNetworking.m
+++ b/AliyunOSSSDK/OSSNetworking.m
@@ -282,19 +282,6 @@
         return ;
     }
 
-    //Correct Clock Skew
-    NSString * dateStr = [[httpResponse allHeaderFields] objectForKey:@"Date"];
-    if ([dateStr length] > 0) {
-        NSDate * serverTime = [NSDate oss_dateFromString:dateStr];
-        NSDate * deviceTime = [NSDate date];
-        NSTimeInterval skewTime = [deviceTime timeIntervalSinceDate:serverTime];
-        [NSDate oss_setClockSkew:skewTime];
-    } else if (!error) {
-        // The response header does not have the 'Date' field.
-        // This should not happen.
-        OSSLogError(@"Date header does not exist, unable to fix the clock skew");
-    }
-
     /* background upload task will not call back didRecieveResponse */
     if (delegate.isBackgroundUploadFileTask) {
         OSSLogVerbose(@"backgroud upload task did recieve response: %@", httpResponse);
@@ -359,6 +346,18 @@
 
                 case OSSNetworkingRetryTypeShouldCorrectClockSkewAndRetry: {
                     /* correct clock skew */
+                    NSString * dateStr = [[httpResponse allHeaderFields] objectForKey:@"Date"];
+                    if ([dateStr length] > 0) {
+                        NSDate * serverTime = [NSDate oss_dateFromString:dateStr];
+                        NSDate * deviceTime = [NSDate date];
+                        NSTimeInterval skewTime = [deviceTime timeIntervalSinceDate:serverTime];
+                        [NSDate oss_setClockSkew:skewTime];
+                    } else if (!error) {
+                        // The response header does not have the 'Date' field.
+                        // This should not happen.
+                        OSSLogError(@"Date header does not exist, unable to fix the clock skew");
+                    }
+                    
                     [delegate.interceptors insertObject:[OSSTimeSkewedFixingInterceptor new] atIndex:0];
                     break;
                 }

--- a/AliyunOSSSDK/OSSNetworkingRequestDelegate.m
+++ b/AliyunOSSSDK/OSSNetworkingRequestDelegate.m
@@ -76,7 +76,7 @@
     // build base url string
     NSString *urlString = self.allNeededMessage.endpoint;
     NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithString:urlString];
-    NSString *headerHost = urlComponents.host;
+    NSString *headerHost = nil;
     
     if ([self.allNeededMessage.bucketName oss_isNotEmpty]) {
         if ([OSSUtil isOssOriginBucketHost:urlComponents.host]) {

--- a/AliyunOSSSDK/OSSNetworkingRequestDelegate.m
+++ b/AliyunOSSSDK/OSSNetworkingRequestDelegate.m
@@ -79,6 +79,7 @@
     NSString *headerHost = nil;
     
     if ([self.allNeededMessage.bucketName oss_isNotEmpty]) {
+        OSSIPv6Adapter *ipAdapter = [OSSIPv6Adapter getInstance];
         if ([OSSUtil isOssOriginBucketHost:urlComponents.host]) {
             // eg. insert bucket to the begining of host.
             urlComponents.host = [NSString stringWithFormat:@"%@.%@", self.allNeededMessage.bucketName, urlComponents.host];
@@ -88,6 +89,8 @@
                 NSString *dnsResult = [OSSUtil getIpByHost: urlComponents.host];
                 urlComponents.host = dnsResult;
             }
+        } else if ([ipAdapter isIPv4Address:urlComponents.host] || [ipAdapter isIPv6Address:urlComponents.host]) {
+            urlComponents.path = [NSString stringWithFormat:@"/%@%@",self.allNeededMessage.bucketName, urlComponents.path];
         }
     }
     

--- a/AliyunOSSSDK/OSSRequest.h
+++ b/AliyunOSSSDK/OSSRequest.h
@@ -21,7 +21,7 @@
 /**
  the flag of request canceled.
  */
-@property (nonatomic, assign) BOOL isCancelled;
+@property (atomic, assign) BOOL isCancelled;
 
 /**
  the flag of verification about crc64

--- a/AliyunOSSSDK/OSSRequest.m
+++ b/AliyunOSSSDK/OSSRequest.m
@@ -27,7 +27,7 @@
 }
 
 - (void)cancel {
-    _isCancelled = YES;
+    self.isCancelled = YES;
     
     if (self.requestDelegate) {
         [self.requestDelegate cancel];

--- a/AliyunOSSiOS.podspec
+++ b/AliyunOSSiOS.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
   s.name         = "AliyunOSSiOS"
 
-  s.version      = "2.10.6"
+  s.version      = "2.10.7"
 
   s.summary      = "An iOS SDK for Aliyun Object Storage Service"
 

--- a/CHANGLOG.txt
+++ b/CHANGLOG.txt
@@ -15,6 +15,13 @@ pod dependency：   pod 'AliyunOSSiOS'
 
 Update Logs:
 
+2018/09/13
+- release 2.10.7
+1.refactor code of building canonical url for request,Keep its logic consistent with android sdk.
+2.fix bug about 409 error when using sequentialUpload api.
+3.optimize synchronization of time.
+4.
+
 2018/08/30
 - release 2.10.6
 1.Add sample about resume download object task from oss server;


### PR DESCRIPTION
将同步服务器时间的逻辑放到重试的逻辑中，正常请求时不再每次都同步时间。以防通过cdn返回的Date同步到错误的缓存时间，导致生成的签名url过期失效问题