### PR TITLE
FIX #241: added mapping of file extension from "mov" to "video/quickt…

### DIFF
--- a/AliyunOSSSDK/OSSUtil.m
+++ b/AliyunOSSSDK/OSSUtil.m
@@ -1039,6 +1039,7 @@ int32_t const CHUNK_SIZE = 8 * 1024;
             @"wvx": @"video/x-ms-wvx",
             @"avi": @"video/x-msvideo",
             @"movie": @"video/x-sgi-movie",
+            @"mov": @"video/quicktime",
             @"ice": @"x-conference/x-cooltalk",
             @"par ": @"text/plain-bas",
             @"yaml": @"text/yaml"


### PR DESCRIPTION
This is a simple fix.

A more general solution from [here](https://stackoverflow.com/questions/9801106/how-can-i-get-mime-type-in-ios-which-is-not-based-on-extension) is listed below, without the need to maintain a map by the SDK.

`NSString *path; // contains the file path

// Get the UTI from the file's extension:

CFStringRef pathExtension = (__bridge_retained CFStringRef)[path pathExtension];
CFStringRef type = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension, NULL);
CFRelease(pathExtension);

// The UTI can be converted to a mime type:

NSString *mimeType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass(type, kUTTagClassMIMEType);
if (type != NULL)
    CFRelease(type);`