### PR TITLE
Make iphonesimulator support arm64

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -28,7 +28,7 @@ $ cd aliyun-oss-ios-sdk
 # 执行打包脚本
 $ sh ./buildiOSFramework.sh
 
-# 进入打包生成目录，AliyunOSSiOS.framework生成在该目录下
+# 进入打包生成目录，AliyunOSSiOS.xcframework生成在该目录下
 $ cd Products && ls
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ cd aliyun-oss-ios-sdk
 # Run the packaging script
 $ sh ./buildiOSFramework.sh
 
-# Enter the generated packaging directory  where the AliyunOSSiOS.framework will be generated
+# Enter the generated packaging directory  where the AliyunOSSiOS.xcframework will be generated
 $ cd Products && ls
 ```
 

--- a/buildiOSFramework.sh
+++ b/buildiOSFramework.sh
@@ -9,7 +9,7 @@ FMK_NAME='AliyunOSSiOS'
 
 # Install dir will be the final output to the framework.
 # The following line create it in the root folder of the current project.
-INSTALL_DIR=${SRCROOT}/Products/${FMK_NAME}.framework
+INSTALL_DIR=${SRCROOT}/Products/${FMK_NAME}.xcframework
 
 # Working dir will be deleted after the framework creation.
 WRK_DIR=./build
@@ -21,7 +21,7 @@ SIMULATOR_DIR=${WRK_DIR}/Release-iphonesimulator/${FMK_NAME}.framework
 # xcodebuild -configuration "Release" -target "${FMK_NAME}" -sdk iphoneos clean build
 # xcodebuild -configuration "Release" -target "${FMK_NAME}" -sdk iphonesimulator clean build
 xcodebuild -configuration Release -workspace "${PROJECT_NAME}.xcworkspace" -scheme "${TARGET_NAME}" -sdk iphoneos clean build SYMROOT="${WRK_DIR}"
-xcodebuild -configuration Release -workspace "${PROJECT_NAME}.xcworkspace" -scheme "${TARGET_NAME}" -sdk iphonesimulator build SYMROOT="${WRK_DIR}" EXCLUDED_ARCHS="arm64"
+xcodebuild -configuration Release -workspace "${PROJECT_NAME}.xcworkspace" -scheme "${TARGET_NAME}" -sdk iphonesimulator build SYMROOT="${WRK_DIR}"
 
 # Cleaning the oldest.
 if [ -d "${INSTALL_DIR}" ]
@@ -31,10 +31,11 @@ fi
 
 mkdir -p ${SRCROOT}/Products
 
-cp -LR "${DEVICE_DIR}" "${INSTALL_DIR}"
-
-# Uses the Lipo Tool to merge both binary files (i386/x86_64 + armv7/armv64) into one Universal final product.
-lipo -create "${DEVICE_DIR}/${FMK_NAME}" "${SIMULATOR_DIR}/${FMK_NAME}" -output "${INSTALL_DIR}/${FMK_NAME}"
+# Create XCFramework
+xcodebuild -create-xcframework \
+-framework "${DEVICE_DIR}" \
+-framework "${SIMULATOR_DIR}" \
+-output "${INSTALL_DIR}"
 
 rm -r "${WRK_DIR}"
 


### PR DESCRIPTION
It makes "iphonesimulator" support the arm64 arch by using XCFramework. It fixed the problem that the developers needed to add "exclude architecture: arm64" in the build settings of their apps using AliyunOSS SDK to run their app on simulators on Apple Silicon Macs. It also fixes the problem that it could not run in the Vision Pro simulator. The fix is verified by replacing the newly compiled SDK in my project, and it works.